### PR TITLE
Fix hide when snackbar not exists

### DIFF
--- a/src/md-snackbars.js
+++ b/src/md-snackbars.js
@@ -52,6 +52,10 @@
     };
 
     hideSnackbar = function () {
+        if (!currentSnackbar) {
+            return;
+        }
+
         //clear timeout in case we hide before delay (click, MDSnackbar.hide())
         clearTimeout(currentSnackbar.timeout);
 


### PR DESCRIPTION
If hide called before show it try to read property timeout of null
